### PR TITLE
Suggest official Neovim config

### DIFF
--- a/docs/resources/configure.md
+++ b/docs/resources/configure.md
@@ -40,21 +40,22 @@ if executable('termux-language-server')
 endif
 ```
 
-## [Neovim](https://neovim.io)
+### [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) (upstream configs)
 
-`~/.config/nvim/init.lua`:
+Example via [`lazy.nvim`](https://github.com/folke/lazy.nvim)\
+For other options see: [nvim-lspconfig#install](https://github.com/neovim/nvim-lspconfig#install)\
+Or the documentation for your plugin manager of choice.
+
+`~/.config/nvim/init.vim`:
 
 ```lua
-vim.api.nvim_create_autocmd({ "BufEnter" }, {
-  pattern = { "build.sh", "*.subpackage.sh", "PKGBUILD", "*.install",
-    "makepkg.conf", "*.ebuild", "*.eclass", "color.map", "make.conf" },
-  callback = function()
-    vim.lsp.start({
-      name = "termux",
-      cmd = { "termux-language-server" }
-    })
-  end,
+require('lazy').setup({
+  -- [...]
+  { 'neovim/nvim-lspconfig' },
+  -- [...]
 })
+
+vim.lsp.enable('termux_language_server')
 ```
 
 ## [Emacs](https://www.gnu.org/software/emacs)


### PR DESCRIPTION
- Neovim's upstream LSP configs have supported termux-language server since neovim/nvim-lspconfig#3947.
That standard config was initially broken, but will be fixed pending neovim/nvim-lspconfig#4161

This PR updates the termux-language-server documentation to reflect the suggested way to add LSPs to Neovim 0.11+.

I have also added some minor documentation cleanup to this PR, and changed the suggested configuration file paths for Emacs and Vim to follow the [XDG Base Directory](https://specifications.freedesktop.org/basedir-spec/latest/) specification.
Which has been supported by Emacs since [version 27.1](https://lists.gnu.org/archive/html/emacs-devel/2020-08/msg00237.html).
And by Vim since [version 9.1.0327](https://github.com/vim/vim/commit/c9df1fb35a1866901c32df37dd39c8b39dbdb64a).